### PR TITLE
Fixes the API docs paths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var docfn = function (urlfn) {
 
 exports.markdown = docfn(function (module) {
   return 'https://raw.githubusercontent.com/nodejs/node/master/doc/api/' +
-    module + '.markdown';
+    module + '.md';
 });
 
 


### PR DESCRIPTION
A recent nodejs/node commit (https://github.com/nodejs/node/commit/0800c0aa7275bf389b157e1568fa61b59285ad86) changed all of the API doc paths to be .md instead of .markdown.
